### PR TITLE
use gcsfs fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ git+https://github.com/tomwhite/scanpy@dask-spark-1.2.2
 dask[array]
 pyspark
 zarr
-gcsfs
+git+https://github.com/lasersonlab/gcsfs@ac23549
 s3fs


### PR DESCRIPTION
https://github.com/lasersonlab/gcsfs/pull/1 (or https://github.com/dask/gcsfs/pull/109) is needed for `cli.py` to be able to write into a requester-pays bucket (e.g. `gs://ll-sc-data`)